### PR TITLE
Display -1 skip

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -124,7 +124,7 @@
 	</div>
 {/if}
 
-{#snippet skipLine(text: string, status: string = 'cleared')}
+{#snippet skipLine(text: string, status: Level['status'])}
 	<div class="border-l border-zinc-400 border-dashed h-8 my-1" />
 	{#if status === 'full_cleared'}
 		<p class="text-purple-400 mt-1">+1 SKIP</p>

--- a/src/routes/share/+page.svelte
+++ b/src/routes/share/+page.svelte
@@ -2,6 +2,7 @@
 	import { plural } from '$lib/util';
 	import LevelBox from '$lib/components/LevelBox.svelte';
 	import Header from '$lib/components/Header.svelte';
+	import { type Level } from '$lib/persist.svelte.js';
 	const { data } = $props();
 	const { levels, initial_skips } = data.shareData;
 
@@ -13,7 +14,7 @@
 	}
 </script>
 
-{#snippet skipLine(text: string, status: string = 'cleared')}
+{#snippet skipLine(text: string, status: Level['status'])}
 	<div class="border-l border-zinc-400 border-dashed h-8 my-1" />
 	{#if status === 'full_cleared'}
 		<p class="text-purple-400 mt-1">+1 SKIP</p>

--- a/src/routes/share/+page.svelte
+++ b/src/routes/share/+page.svelte
@@ -6,6 +6,15 @@
 	const { data } = $props();
 	const { levels, initial_skips } = data.shareData;
 
+	const deltaSkips = {
+		full_cleared: 1,
+		skipped: -1,
+	};
+
+	function getDeltaSkip(status: Level['status']) {
+		return deltaSkips[status as keyof typeof deltaSkips] ?? 0;
+	}
+
 	const cumulativeClears: number[] = [];
 	let sum = 0;
 	for (const level of levels) {
@@ -14,18 +23,16 @@
 	}
 </script>
 
-{#snippet skipLine(text: string, status: Level['status'])}
+{#snippet skipLine(text: string, deltaSkips = 0)}
 	<div class="border-l border-zinc-400 border-dashed h-8 my-1" />
-	{#if status === 'full_cleared'}
-		<p class="text-purple-400 mt-1">+1 SKIP</p>
-	{:else if status === 'skipped'}
-		<p class="text-yellow-400 mt-1">-1 SKIP</p>
+	{#if deltaSkips > 0}
+		<p class="text-purple-400 mt-1">+{deltaSkips} {plural('SKIP', deltaSkips).toUpperCase()}</p>
+	{:else if deltaSkips < 0}
+		<p class="text-yellow-400 mt-1">-{-deltaSkips} {plural('SKIP', deltaSkips).toUpperCase()}</p>
 	{/if}
 	<p class="text-sm text-zinc-400 uppercase">{text}</p>
 	<div class="border-l border-zinc-400 border-dashed h-8 my-1" />
 {/snippet}
-
-
 
 <main class="flex items-center flex-col max-w-screen-lg mx-auto p-8">
 	<Header />
@@ -43,7 +50,7 @@
 				{@const  clears = cumulativeClears[i]!}
 				{@render skipLine(
 					`${clears} ${plural('clear', clears)}, ${skips} ${plural('skip', skips)}`,
-					level.status,
+					getDeltaSkip(level.status),
 				)}
 			{/if}
 		{/each}

--- a/src/routes/share/+page.svelte
+++ b/src/routes/share/+page.svelte
@@ -13,14 +13,18 @@
 	}
 </script>
 
-{#snippet skipLine(text: string, plus1 = false)}
+{#snippet skipLine(text: string, status: string = 'cleared')}
 	<div class="border-l border-zinc-400 border-dashed h-8 my-1" />
-	{#if plus1}
+	{#if status === 'full_cleared'}
 		<p class="text-purple-400 mt-1">+1 SKIP</p>
+	{:else if status === 'skipped'}
+		<p class="text-yellow-400 mt-1">-1 SKIP</p>
 	{/if}
 	<p class="text-sm text-zinc-400 uppercase">{text}</p>
 	<div class="border-l border-zinc-400 border-dashed h-8 my-1" />
 {/snippet}
+
+
 
 <main class="flex items-center flex-col max-w-screen-lg mx-auto p-8">
 	<Header />
@@ -29,28 +33,28 @@
 		{@render skipLine(
 			`Start, ${initial_skips} ${plural('skip', initial_skips)}`,
 		)}
-	{/if}
-	{#each levels as level, i (level.url)}
-		{#if level.status !== 'error' && level.status !== 'loading'}
-			<LevelBox {level} />
+		{#each levels as level, i (level.url)}
+			{#if level.status !== 'error' && level.status !== 'loading'}
+				<LevelBox {level} />
+			{/if}
+			{#if i < levels.length - 1}
+				{@const  skips = levels[i + 1]!.skips_at_start}
+				{@const  clears = cumulativeClears[i]!}
+				{@render skipLine(
+					`${clears} ${plural('clear', clears)}, ${skips} ${plural('skip', skips)}`,
+					level.status,
+				)}
+			{/if}
+		{/each}
+		{#if levels.last?.status === 'failed'}
+			{@const clears = cumulativeClears[cumulativeClears.length - 1] ?? 0}
+			<div class="border-l border-zinc-400 border-dashed h-8 mt-1" />
+			<div class="text-center text-zinc-200 uppercase my-1">
+				<p class="text-red-400">Game Over!</p>
+				<p class="tabular-nums">Score: {clears} {plural('clear', clears)}.</p>
+			</div>
+			<a href="/" class="btn">Play</a>
 		{/if}
-		{#if i < levels.length - 1}
-			{@const  skips = levels[i + 1]!.skips_at_start}
-			{@const  clears = cumulativeClears[i]!}
-			{@render skipLine(
-				`${clears} ${plural('clear', clears)}, ${skips} ${plural('skip', skips)}`,
-				level.status === 'full_cleared',
-			)}
-		{/if}
-	{/each}
-	{#if levels[levels.length - 1]?.status === 'failed'}
-		{@const clears = cumulativeClears[cumulativeClears.length - 1] ?? 0}
-		<div class="border-l border-zinc-400 border-dashed h-8 mt-1" />
-		<div class="text-center text-zinc-200 uppercase my-1">
-			<p class="text-red-400">Game Over!</p>
-			<p class="tabular-nums">Score: {clears} {plural('clear', clears)}.</p>
-		</div>
-		<a href="/" class="btn">Play</a>
 	{/if}
 	<div class="h-[300px]" />
 </main>


### PR DESCRIPTION
Similar to how +1 skip occurs on a full clear, this does the same thing and displays -1 on a skip.

![image](https://github.com/ottomated/celeste-random-golden/assets/58920010/5a731d36-0a2f-4784-b972-05fd40f0737d)

It moves the level box rendering code into the `{#if levels.length > 0}` statement. (This seems to fix some bug where the rendering of the levels completely breaks down when ran locally through `npm run dev`. Shouldn't change behavior?)

It also just replaces `levels[levels.length - 1]?.status` with `levels.last?.status` in `+page.svelte`. 